### PR TITLE
Add context manager/decorator to set context gfyear (+ misc. cleanup)

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 import unittest
 from tktitler import (
-    tk_prefix, ktk_prefix, tk_postfix,
+    tk_prefix, tk_kprefix, tk_postfix,
     get_gfyear, override,
     parse_relative, parse,
     PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
@@ -144,26 +144,26 @@ class TestPrefixUnicode(unittest.TestCase):
 class TestKprefix(unittest.TestCase):
 
     def test_sameyear(self):
-        self.assertEqual(ktk_prefix(("CERM", 2016), 2016), "KGCERM")
+        self.assertEqual(tk_kprefix(("CERM", 2016), 2016), "KGCERM")
 
     def test_year_minus_01(self):
-        self.assertEqual(ktk_prefix(("CERM", 2015), 2016), "KBCERM")
+        self.assertEqual(tk_kprefix(("CERM", 2015), 2016), "KBCERM")
 
     def test_year_minus_04(self):
-        self.assertEqual(ktk_prefix(("CERM", 2012), 2016), "KT2OCERM")
+        self.assertEqual(tk_kprefix(("CERM", 2012), 2016), "KT2OCERM")
 
     def test_year_minus_05(self):
-        self.assertEqual(ktk_prefix(("CERM", 2011), 2016), "KT3OCERM")
+        self.assertEqual(tk_kprefix(("CERM", 2011), 2016), "KT3OCERM")
 
     def test_year_plus_1(self):
-        self.assertEqual(ktk_prefix(("CERM", 2017), 2016), "KCERM")
+        self.assertEqual(tk_kprefix(("CERM", 2017), 2016), "KCERM")
 
     def test_year_plus_2(self):
-        self.assertEqual(ktk_prefix(("CERM", 2018), 2016), "K2CERM")
+        self.assertEqual(tk_kprefix(("CERM", 2018), 2016), "K2CERM")
 
     def test_unicode_year_minus_05(self):
         self.assertEqual(
-            ktk_prefix(("CERM", 2011), 2016, type=PREFIXTYPE_UNICODE),
+            tk_kprefix(("CERM", 2011), 2016, type=PREFIXTYPE_UNICODE),
             "KT³OCERM")
 
 
@@ -217,7 +217,7 @@ class TestOverride(unittest.TestCase):
 
     def test_kprefix(self):
         with override(2015):
-            self.assertEqual(ktk_prefix(('CERM', 2014)), 'KOCERM')
+            self.assertEqual(tk_kprefix(('CERM', 2014)), 'KOCERM')
 
     def test_postfix(self):
         with override(2015):

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import unittest
 from tktitler import (
     tk_prefix, ktk_prefix, tk_postfix,
     get_gfyear, override,
+    parse_relative,
     PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
     POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE, POSTFIXTYPE_SLASH,
     POSTFIXTYPE_LONGSINGLE, POSTFIXTYPE_LONGSLASH,
@@ -221,6 +222,57 @@ class TestOverride(unittest.TestCase):
     def test_postfix(self):
         with override(2015):
             self.assertEqual(tk_postfix(('CERM', 2014)), 'CERM14')
+
+
+class TestParseRelative(unittest.TestCase):
+
+    def test_relative_current(self):
+        self.assertEqual(parse_relative('FORM'), (0, 'FORM', None))
+
+    def test_simple_prefix(self):
+        self.assertEqual(parse_relative('GFORM'), (1, 'FORM', None))
+
+    def test_multi_prefix(self):
+        self.assertEqual(parse_relative('BTKFORM'), (2, 'FORM', None))
+
+    def test_exponent(self):
+        self.assertEqual(parse_relative('OT2OFORM'), (8, 'FORM', None))
+
+    def test_short_postfix(self):
+        self.assertEqual(parse_relative('OT2OFORM16'), (8, 'FORM', 2016))
+
+    def test_long_postfix(self):
+        self.assertEqual(parse_relative('FORM1516'), (0, 'FORM', 2015))
+
+    def test_full_postfix(self):
+        self.assertEqual(parse_relative('FORM2015'), (0, 'FORM', 2015))
+
+    def test_fu(self):
+        self.assertEqual(parse_relative('GFU14'), (1, 'FU', 2014))
+
+    def test_fu_int(self):
+        self.assertEqual(parse_relative('GFUOEAE14'), (1, 'FUOEAE', 2014))
+
+    def test_lower(self):
+        self.assertEqual(parse_relative('gfuoeae14'), (1, 'FUOEAE', 2014))
+
+    def test_unicode_superscript(self):
+        self.assertEqual(parse_relative('T²OFORM'), (5, 'FORM', None))
+
+    def test_kass_dollar(self):
+        self.assertEqual(parse_relative('GKA$$'), (1, 'KASS', None))
+
+    def test_kass_funny(self):
+        self.assertEqual(parse_relative('GKA$\N{POUND SIGN}'),
+                         (1, 'KASS', None))
+
+    def test_cerm_funny(self):
+        self.assertEqual(parse_relative('\N{DOUBLE-STRUCK CAPITAL C}ERM'),
+                         (0, 'CERM', None))
+
+    def test_unknown(self):
+        self.assertEqual(parse_relative('OABEN'),
+                         (3, 'ABEN', None))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,186 +1,196 @@
 import unittest
-from tktitler import (prefix, PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE, kprefix,
-                      postfix, POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE,
-                      POSTFIXTYPE_SLASH, POSTFIXTYPE_LONGSINGLE,
-                      POSTFIXTYPE_LONGSLASH)
+from tktitler import (
+    tk_prefix, ktk_prefix, tk_postfix,
+    PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
+    POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE, POSTFIXTYPE_SLASH,
+    POSTFIXTYPE_LONGSINGLE, POSTFIXTYPE_LONGSLASH,
+)
 
 
 class TestPrefixNormal(unittest.TestCase):
 
     def test_sameyear(self):
-        self.assertEqual(prefix(("CERM", 2016), 2016), "CERM")
+        self.assertEqual(tk_prefix(("CERM", 2016), 2016), "CERM")
 
     def test_year_minus_01(self):
-        self.assertEqual(prefix(("CERM", 2015), 2016), "GCERM")
+        self.assertEqual(tk_prefix(("CERM", 2015), 2016), "GCERM")
 
     def test_year_minus_02(self):
-        self.assertEqual(prefix(("CERM", 2014), 2016), "BCERM")
+        self.assertEqual(tk_prefix(("CERM", 2014), 2016), "BCERM")
 
     def test_year_minus_03(self):
-        self.assertEqual(prefix(("CERM", 2013), 2016), "OCERM")
+        self.assertEqual(tk_prefix(("CERM", 2013), 2016), "OCERM")
 
     def test_year_minus_04(self):
-        self.assertEqual(prefix(("CERM", 2012), 2016), "TOCERM")
+        self.assertEqual(tk_prefix(("CERM", 2012), 2016), "TOCERM")
 
     def test_year_minus_05(self):
-        self.assertEqual(prefix(("CERM", 2011), 2016), "T2OCERM")
+        self.assertEqual(tk_prefix(("CERM", 2011), 2016), "T2OCERM")
 
     def test_year_minus_15(self):
-        self.assertEqual(prefix(("CERM", 2001), 2016), "T12OCERM")
+        self.assertEqual(tk_prefix(("CERM", 2001), 2016), "T12OCERM")
 
     def test_year_minus_36(self):
-        self.assertEqual(prefix(("CERM", 1980), 2016), "T33OCERM")
+        self.assertEqual(tk_prefix(("CERM", 1980), 2016), "T33OCERM")
 
     def test_year_plus_1(self):
-        self.assertEqual(prefix(("CERM", 2017), 2016), "KCERM")
+        self.assertEqual(tk_prefix(("CERM", 2017), 2016), "KCERM")
 
     def test_year_plus_2(self):
-        self.assertEqual(prefix(("CERM", 2018), 2016), "K2CERM")
+        self.assertEqual(tk_prefix(("CERM", 2018), 2016), "K2CERM")
 
     def test_year_plus_15(self):
-        self.assertEqual(prefix(("CERM", 2031), 2016), "K15CERM")
+        self.assertEqual(tk_prefix(("CERM", 2031), 2016), "K15CERM")
 
     def test_KASS(self):
-        self.assertEqual(prefix(("KASS", 2016), 2016), "KA$$")
+        self.assertEqual(tk_prefix(("KASS", 2016), 2016), "KA$$")
 
     def test_FUSS(self):
-        self.assertEqual(prefix(("FUSS", 2016), 2016), "FUSS")
+        self.assertEqual(tk_prefix(("FUSS", 2016), 2016), "FUSS")
 
     def test_FUAEAE(self):
-        self.assertEqual(prefix(("FUÆÆ", 2016), 2016), "FUÆÆ")
+        self.assertEqual(tk_prefix(("FUÆÆ", 2016), 2016), "FUÆÆ")
 
     def test_FUOEOE(self):
-        self.assertEqual(prefix(("FUØØ", 2016), 2016), "FUØØ")
+        self.assertEqual(tk_prefix(("FUØØ", 2016), 2016), "FUØØ")
 
     def test_FUAAAA(self):
-        self.assertEqual(prefix(("FUÅÅ", 2016), 2016), "FUÅÅ")
+        self.assertEqual(tk_prefix(("FUÅÅ", 2016), 2016), "FUÅÅ")
 
     def test_empty(self):
-        self.assertEqual(prefix(("", 2016), 2016), "")
+        self.assertEqual(tk_prefix(("", 2016), 2016), "")
 
     def test_empty_minus_04(self):
-        self.assertEqual(prefix(("", 2012), 2016), "TO")
+        self.assertEqual(tk_prefix(("", 2012), 2016), "TO")
 
     def test_empty_minus_15(self):
-        self.assertEqual(prefix(("", 2001), 2016), "T12O")
+        self.assertEqual(tk_prefix(("", 2001), 2016), "T12O")
 
     def test_longstring(self):
-        self.assertEqual(prefix(("This is a quite long string", 2012), 2016),
-                         "TOThis is a quite long string")
+        self.assertEqual(tk_prefix(("This is a long string", 2012), 2016),
+                         "TOThis is a long string")
 
     def test_explicit_type_plus_2(self):
-        self.assertEqual(prefix(("CERM", 2018), 2016, type=PREFIXTYPE_NORMAL),
-                         "K2CERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2018), 2016, type=PREFIXTYPE_NORMAL), "K2CERM")
 
     def test_explicit_type_minus_15(self):
-        self.assertEqual(prefix(("CERM", 2001), 2016, type=PREFIXTYPE_NORMAL),
-                         "T12OCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2001), 2016, type=PREFIXTYPE_NORMAL),
+            "T12OCERM")
 
     def test_validation_root_int(self):
         with self.assertRaisesRegex(TypeError,
                                     "int is not a valid type for root."):
-            prefix((0, 2012), 2016)
+            tk_prefix((0, 2012), 2016)
 
     def test_validation_period_float(self):
         with self.assertRaisesRegex(TypeError,
                                     "float is not a valid type for period."):
-            prefix(("CERM", 2012.), 2016)
+            tk_prefix(("CERM", 2012.), 2016)
 
     def test_validation_period_string(self):
         with self.assertRaisesRegex(TypeError,
                                     "str is not a valid type for period."):
-            prefix(("CERM", '2012'), 2016)
+            tk_prefix(("CERM", '2012'), 2016)
 
     def test_validation_gfyear_string(self):
         with self.assertRaisesRegex(TypeError,
                                     "str is not a valid type for gfyear."):
-            prefix(("CERM", 2012), "2016")
+            tk_prefix(("CERM", 2012), "2016")
 
 
 class TestPrefixUnicode(unittest.TestCase):
 
     def test_sameyear(self):
-        self.assertEqual(prefix(("CERM", 2016), 2016, type=PREFIXTYPE_UNICODE),
-                         "CERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2016), 2016, type=PREFIXTYPE_UNICODE), "CERM")
 
     def test_year_minus_01(self):
-        self.assertEqual(prefix(("CERM", 2015), 2016, type=PREFIXTYPE_UNICODE),
-                         "GCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2015), 2016, type=PREFIXTYPE_UNICODE), "GCERM")
 
     def test_year_minus_05(self):
-        self.assertEqual(prefix(("CERM", 2011), 2016, type=PREFIXTYPE_UNICODE),
-                         "T²OCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2011), 2016, type=PREFIXTYPE_UNICODE),
+            "T²OCERM")
 
     def test_year_minus_13(self):
-        self.assertEqual(prefix(("CERM", 2003), 2016, type=PREFIXTYPE_UNICODE),
-                         "T¹⁰OCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2003), 2016, type=PREFIXTYPE_UNICODE),
+            "T¹⁰OCERM")
 
     def test_year_minus_36(self):
-        self.assertEqual(prefix(("CERM", 1980), 2016, type=PREFIXTYPE_UNICODE),
-                         "T³³OCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 1980), 2016, type=PREFIXTYPE_UNICODE),
+            "T³³OCERM")
 
     def test_year_plus_1(self):
-        self.assertEqual(prefix(("CERM", 2017), 2016, type=PREFIXTYPE_UNICODE),
-                         "KCERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2017), 2016, type=PREFIXTYPE_UNICODE), "KCERM")
 
     def test_year_plus_2(self):
-        self.assertEqual(prefix(("CERM", 2018), 2016, type=PREFIXTYPE_UNICODE),
-                         "K²CERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2018), 2016, type=PREFIXTYPE_UNICODE), "K²CERM")
 
     def test_year_plus_15(self):
-        self.assertEqual(prefix(("CERM", 2031), 2016, type=PREFIXTYPE_UNICODE),
-                         "K¹⁵CERM")
+        self.assertEqual(
+            tk_prefix(("CERM", 2031), 2016, type=PREFIXTYPE_UNICODE),
+            "K¹⁵CERM")
 
 
 class TestKprefix(unittest.TestCase):
 
     def test_sameyear(self):
-        self.assertEqual(kprefix(("CERM", 2016), 2016), "KGCERM")
+        self.assertEqual(ktk_prefix(("CERM", 2016), 2016), "KGCERM")
 
     def test_year_minus_01(self):
-        self.assertEqual(kprefix(("CERM", 2015), 2016), "KBCERM")
+        self.assertEqual(ktk_prefix(("CERM", 2015), 2016), "KBCERM")
 
     def test_year_minus_04(self):
-        self.assertEqual(kprefix(("CERM", 2012), 2016), "KT2OCERM")
+        self.assertEqual(ktk_prefix(("CERM", 2012), 2016), "KT2OCERM")
 
     def test_year_minus_05(self):
-        self.assertEqual(kprefix(("CERM", 2011), 2016), "KT3OCERM")
+        self.assertEqual(ktk_prefix(("CERM", 2011), 2016), "KT3OCERM")
 
     def test_year_plus_1(self):
-        self.assertEqual(kprefix(("CERM", 2017), 2016), "KCERM")
+        self.assertEqual(ktk_prefix(("CERM", 2017), 2016), "KCERM")
 
     def test_year_plus_2(self):
-        self.assertEqual(kprefix(("CERM", 2018), 2016), "K2CERM")
+        self.assertEqual(ktk_prefix(("CERM", 2018), 2016), "K2CERM")
 
     def test_unicode_year_minus_05(self):
-        self.assertEqual(kprefix(("CERM", 2011), 2016,
-                                 type=PREFIXTYPE_UNICODE), "KT³OCERM")
+        self.assertEqual(
+            ktk_prefix(("CERM", 2011), 2016, type=PREFIXTYPE_UNICODE),
+            "KT³OCERM")
 
 
 class TestPostfix(unittest.TestCase):
 
     def test_notype(self):
-        self.assertEqual(postfix(("CERM", 2016)), "CERM16")
+        self.assertEqual(tk_postfix(("CERM", 2016)), "CERM16")
 
     def test_explicit_type(self):
-        self.assertEqual(postfix(("CERM", 2016), type=POSTFIXTYPE_SINGLE),
+        self.assertEqual(tk_postfix(("CERM", 2016), type=POSTFIXTYPE_SINGLE),
                          "CERM16")
 
     def test_double(self):
-        self.assertEqual(postfix(("CERM", 2016), type=POSTFIXTYPE_DOUBLE),
+        self.assertEqual(tk_postfix(("CERM", 2016), type=POSTFIXTYPE_DOUBLE),
                          "CERM1617")
 
     def test_slash(self):
-        self.assertEqual(postfix(("CERM", 2016), type=POSTFIXTYPE_SLASH),
+        self.assertEqual(tk_postfix(("CERM", 2016), type=POSTFIXTYPE_SLASH),
                          "CERM16/17")
 
     def test_longsingle(self):
-        self.assertEqual(postfix(("CERM", 2016), type=POSTFIXTYPE_LONGSINGLE),
-                         "CERM2016")
+        self.assertEqual(
+            tk_postfix(("CERM", 2016), type=POSTFIXTYPE_LONGSINGLE),
+            "CERM2016")
 
     def test_longslash(self):
-        self.assertEqual(postfix(("CERM", 2016), type=POSTFIXTYPE_LONGSLASH),
-                         "CERM2016/2017")
+        self.assertEqual(
+            tk_postfix(("CERM", 2016), type=POSTFIXTYPE_LONGSLASH),
+            "CERM2016/2017")
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import unittest
 from tktitler import (
     tk_prefix, ktk_prefix, tk_postfix,
+    get_gfyear, override,
     PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
     POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE, POSTFIXTYPE_SLASH,
     POSTFIXTYPE_LONGSINGLE, POSTFIXTYPE_LONGSLASH,
@@ -191,6 +192,35 @@ class TestPostfix(unittest.TestCase):
         self.assertEqual(
             tk_postfix(("CERM", 2016), type=POSTFIXTYPE_LONGSLASH),
             "CERM2016/2017")
+
+
+class TestOverride(unittest.TestCase):
+
+    def test_decorator(self):
+        self.assertEqual(override(2013)(get_gfyear)(), 2013)
+
+    def test_context_manager(self):
+        with override(2012):
+            self.assertEqual(get_gfyear(), 2012)
+
+    def test_reentrant(self):
+        with override(2011):
+            self.assertEqual(get_gfyear(), 2011)
+            with override(2012):
+                self.assertEqual(get_gfyear(), 2012)
+            self.assertEqual(get_gfyear(), 2011)
+
+    def test_prefix(self):
+        with override(2015):
+            self.assertEqual(tk_prefix(('CERM', 2014)), 'GCERM')
+
+    def test_kprefix(self):
+        with override(2015):
+            self.assertEqual(ktk_prefix(('CERM', 2014)), 'KOCERM')
+
+    def test_postfix(self):
+        with override(2015):
+            self.assertEqual(tk_postfix(('CERM', 2014)), 'CERM14')
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 import unittest
 from tktitler import (
     tk_prefix, tk_kprefix, tk_postfix,
-    get_gfyear, override,
+    get_gfyear, set_gfyear,
     parse_relative, parse,
     PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
     POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE, POSTFIXTYPE_SLASH,
@@ -198,29 +198,29 @@ class TestPostfix(unittest.TestCase):
 class TestOverride(unittest.TestCase):
 
     def test_decorator(self):
-        self.assertEqual(override(2013)(get_gfyear)(), 2013)
+        self.assertEqual(set_gfyear(2013)(get_gfyear)(), 2013)
 
     def test_context_manager(self):
-        with override(2012):
+        with set_gfyear(2012):
             self.assertEqual(get_gfyear(), 2012)
 
     def test_reentrant(self):
-        with override(2011):
+        with set_gfyear(2011):
             self.assertEqual(get_gfyear(), 2011)
-            with override(2012):
+            with set_gfyear(2012):
                 self.assertEqual(get_gfyear(), 2012)
             self.assertEqual(get_gfyear(), 2011)
 
     def test_prefix(self):
-        with override(2015):
+        with set_gfyear(2015):
             self.assertEqual(tk_prefix(('CERM', 2014)), 'GCERM')
 
     def test_kprefix(self):
-        with override(2015):
+        with set_gfyear(2015):
             self.assertEqual(tk_kprefix(('CERM', 2014)), 'KOCERM')
 
     def test_postfix(self):
-        with override(2015):
+        with set_gfyear(2015):
             self.assertEqual(tk_postfix(('CERM', 2014)), 'CERM14')
 
 
@@ -281,11 +281,11 @@ class TestParse(unittest.TestCase):
         self.assertEqual(parse('FORM', 2016), ('FORM', 2016))
 
     def test_context(self):
-        with override(2013):
+        with set_gfyear(2013):
             self.assertEqual(parse('FORM'), ('FORM', 2013))
 
     def test_postfix(self):
-        with override(2013):
+        with set_gfyear(2013):
             self.assertEqual(parse('FORM16'), ('FORM', 2016))
 
 

--- a/test.py
+++ b/test.py
@@ -217,7 +217,7 @@ class TestOverride(unittest.TestCase):
 
     def test_kprefix(self):
         with set_gfyear(2015):
-            self.assertEqual(tk_kprefix(('CERM', 2014)), 'KOCERM')
+            self.assertEqual(tk_kprefix(('CERM', 2014)), 'KBCERM')
 
     def test_postfix(self):
         with set_gfyear(2015):

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import unittest
 from tktitler import (
     tk_prefix, ktk_prefix, tk_postfix,
     get_gfyear, override,
-    parse_relative,
+    parse_relative, parse,
     PREFIXTYPE_NORMAL, PREFIXTYPE_UNICODE,
     POSTFIXTYPE_SINGLE, POSTFIXTYPE_DOUBLE, POSTFIXTYPE_SLASH,
     POSTFIXTYPE_LONGSINGLE, POSTFIXTYPE_LONGSLASH,
@@ -273,6 +273,20 @@ class TestParseRelative(unittest.TestCase):
     def test_unknown(self):
         self.assertEqual(parse_relative('OABEN'),
                          (3, 'ABEN', None))
+
+
+class TestParse(unittest.TestCase):
+
+    def test_arg(self):
+        self.assertEqual(parse('FORM', 2016), ('FORM', 2016))
+
+    def test_context(self):
+        with override(2013):
+            self.assertEqual(parse('FORM'), ('FORM', 2013))
+
+    def test_postfix(self):
+        with override(2013):
+            self.assertEqual(parse('FORM16'), ('FORM', 2016))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -274,6 +274,12 @@ class TestParseRelative(unittest.TestCase):
         self.assertEqual(parse_relative('OABEN'),
                          (3, 'ABEN', None))
 
+    def test_prefix(self):
+        self.assertEqual(parse_relative('G12'), (12, '', None))
+
+    def test_postfix(self):
+        self.assertEqual(parse_relative('12'), (0, '', 2012))
+
 
 class TestParse(unittest.TestCase):
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -51,8 +51,8 @@ def override(gfyear):
     return _Override(gfyear)
 
 
-def tk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
-    _validate(titletupel, gfyear)
+def tk_prefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
+    gfyear = _validate(titletupel, gfyear)
 
     root, period = titletupel
     root = _funny_substitute(root)
@@ -99,8 +99,8 @@ POSTFIXTYPE_LONGSINGLE = "longsingle"  # FUHØ2011
 POSTFIXTYPE_LONGSLASH = "longslash"  # FUHØ2011/2012
 
 
-def tk_postfix(titletupel, gfyear=gfyear, type=POSTFIXTYPE_SINGLE):
-    _validate(titletupel, gfyear)
+def tk_postfix(titletupel, gfyear=None, type=POSTFIXTYPE_SINGLE):
+    gfyear = _validate(titletupel, gfyear)
 
     root, period = titletupel
     root = _funny_substitute(root)
@@ -128,8 +128,8 @@ EMAILTYPE_POSTFIX = "postfix"  # FUHOE11
 EMAILTYPE_PREFIX = "prefix"  # T2OFUHOE
 
 
-def email(titletupel, gfyear=gfyear, type=EMAILTYPE_POSTFIX):
-    _validate(titletupel, gfyear)
+def email(titletupel, gfyear=None, type=EMAILTYPE_POSTFIX):
+    gfyear = _validate(titletupel, gfyear)
 
     root, period = titletupel
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -80,6 +80,7 @@ def tk_postfix(titletupel, gfyear=gfyear, type=POSTFIXTYPE_SINGLE):
     else:
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
 
+    assert isinstance(root + postfix, str)
     return "" + root + postfix
 
 
@@ -104,6 +105,7 @@ def email(titletupel, gfyear=gfyear, type=EMAILTYPE_POSTFIX):
         prefix = tk_prefix(("", period), gfyear, type=PREFIXTYPE_NORMAL)
     else:
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
+    assert isinstance(prefix + root + postfix, str)
     return "" + prefix + root + postfix
 
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -12,6 +12,19 @@ PREFIXTYPE_NORMAL = "normal"
 PREFIXTYPE_UNICODE = "unicode"
 
 
+def get_gfyear(argument_gfyear=None):
+    if argument_gfyear is None:
+        r = gfyear
+    else:
+        r = argument_gfyear
+    if not isinstance(r, int):
+        raise TypeError(
+            "%s is not a valid type for gfyear." % type(r).__name__)
+    if len(str(r)) != 4:
+        raise ValueError("\'%s\' is not a valid gfyear" % r)
+    return r
+
+
 class _Override(object):
     def __init__(self, context_gfyear):
         self.context_gfyear = context_gfyear
@@ -150,11 +163,7 @@ def _validate(titletupel, gfyear):
             "%s is not a valid type for period." % type(period).__name__)
     if not len(str(period)) == 4:
         raise ValueError("\'%s\' is not a valid period" % period)
-    if not isinstance(gfyear, int):
-        raise TypeError(
-            "%s is not a valid type for gfyear." % type(gfyear).__name__)
-    if not len(str(gfyear)) == 4:
-        raise ValueError("\'%s\' is not a valid gfyear" % gfyear)
+    return get_gfyear(gfyear)
 
 
 def _funny_substitute(root):

--- a/tktitler.py
+++ b/tktitler.py
@@ -239,7 +239,7 @@ def parse(alias, gfyear=None):
     return root, gfyear - age
 
 
-def _validate(titletupel, gfyear):
+def _validate_title(titletuple):
     root, period = titletupel
     if not isinstance(root, str):
         raise TypeError(
@@ -249,6 +249,10 @@ def _validate(titletupel, gfyear):
             "%s is not a valid type for period." % type(period).__name__)
     if not len(str(period)) == 4:
         raise ValueError("\'%s\' is not a valid period" % period)
+
+
+def _validate(titletupel, gfyear):
+    _validate_title(titletuple)
     return get_gfyear(gfyear)
 
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -150,7 +150,7 @@ def email(titletupel, gfyear=None, type=EMAILTYPE_POSTFIX):
     return prefix + root + postfix
 
 
-def normalize(input_alias):
+def _normalize(input_alias):
     table = {'$': 'S',
              '\N{POUND SIGN}': 'S',
              '\N{DOUBLE-STRUCK CAPITAL C}': 'C'}
@@ -210,7 +210,7 @@ def parse_postfix(postfix):
 
 
 def parse_relative(input_alias):
-    alias = normalize(input_alias)
+    alias = _normalize(input_alias)
     prefix = r"(?P<pre>(?:[KGBOT][KGBOT0-9]*)?)"
     postfix = r"(?P<post>[0-9]*)"
     letter = '[A-Z]|Æ|Ø|Å|AE|OE|AA'

--- a/tktitler.py
+++ b/tktitler.py
@@ -11,7 +11,7 @@ PREFIXTYPE_NORMAL = "normal"
 PREFIXTYPE_UNICODE = "unicode"
 
 
-def prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
+def tk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
     _validate(titletupel, gfyear)
 
     root, period = titletupel
@@ -46,10 +46,10 @@ def kprefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
     root, period = titletupel
     age = gfyear - period
     if age <= -1:
-        return prefix((root, period), gfyear, type)
+        return tk_prefix((root, period), gfyear, type)
 
     period -= 1
-    return "K" + prefix((root, period), gfyear, type)
+    return "K" + tk_prefix((root, period), gfyear, type)
 
 
 POSTFIXTYPE_SINGLE = "single"  # FUHØ11
@@ -59,7 +59,7 @@ POSTFIXTYPE_LONGSINGLE = "longsingle"  # FUHØ2011
 POSTFIXTYPE_LONGSLASH = "longslash"  # FUHØ2011/2012
 
 
-def postfix(titletupel, gfyear=gfyear, type=POSTFIXTYPE_SINGLE):
+def tk_postfix(titletupel, gfyear=gfyear, type=POSTFIXTYPE_SINGLE):
     _validate(titletupel, gfyear)
 
     root, period = titletupel
@@ -101,7 +101,7 @@ def email(titletupel, gfyear=gfyear, type=EMAILTYPE_POSTFIX):
     if type == EMAILTYPE_POSTFIX:
         postfix_ = str(period)[2:4]
     elif type == EMAILTYPE_PREFIX:
-        prefix_ = prefix(("", period), gfyear, type=PREFIXTYPE_NORMAL)
+        prefix_ = tk_prefix(("", period), gfyear, type=PREFIXTYPE_NORMAL)
     else:
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
     return "" + prefix_ + root + postfix_

--- a/tktitler.py
+++ b/tktitler.py
@@ -239,7 +239,7 @@ def parse(alias, gfyear=None):
     return root, gfyear - age
 
 
-def _validate_title(titletuple):
+def _validate_title(titletupel):
     root, period = titletupel
     if not isinstance(root, str):
         raise TypeError(
@@ -252,7 +252,7 @@ def _validate_title(titletuple):
 
 
 def _validate(titletupel, gfyear):
-    _validate_title(titletuple)
+    _validate_title(titletupel)
     return get_gfyear(gfyear)
 
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -288,6 +288,7 @@ def get_period(prefix, postfix, gfyear=None):
     If both strings are empty, the gfyear is returned:
     >>> get_period("", "", 2016)
     2016
+
     If only a prefix is given, it is subtracted from the gfyear:
     >>> get_period("B", "", 2016)
     2014
@@ -295,6 +296,7 @@ def get_period(prefix, postfix, gfyear=None):
     2010
     >>> get_period("G2B2", "", 2016)
     2010
+
     These are the three different ways of writing 2010 as postfix.
     Note that the gfyear is ignored when postfix is given.
     >>> get_period("", "2010", 2016)
@@ -303,6 +305,7 @@ def get_period(prefix, postfix, gfyear=None):
     2010
     >>> get_period("", "1011", 2018)
     2010
+
     If both prefix and postfix are given, the prefix is subtracted from
     the postfix, and the gfyear is ignored:
     >>> get_period("O", "2016", 2030)

--- a/tktitler.py
+++ b/tktitler.py
@@ -81,7 +81,7 @@ def tk_postfix(titletupel, gfyear=gfyear, type=POSTFIXTYPE_SINGLE):
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
 
     assert isinstance(root + postfix, str)
-    return "" + root + postfix
+    return root + postfix
 
 
 EMAILTYPE_POSTFIX = "postfix"  # FUHOE11
@@ -106,7 +106,7 @@ def email(titletupel, gfyear=gfyear, type=EMAILTYPE_POSTFIX):
     else:
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
     assert isinstance(prefix + root + postfix, str)
-    return "" + prefix + root + postfix
+    return prefix + root + postfix
 
 
 def parse(alias, gfyear=gfyear):

--- a/tktitler.py
+++ b/tktitler.py
@@ -96,15 +96,15 @@ def email(titletupel, gfyear=gfyear, type=EMAILTYPE_POSTFIX):
                     'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA'}
     root = _multireplace(root, replace_dict)
 
-    prefix_ = ""
-    postfix_ = ""
+    prefix = ""
+    postfix = ""
     if type == EMAILTYPE_POSTFIX:
-        postfix_ = str(period)[2:4]
+        postfix = str(period)[2:4]
     elif type == EMAILTYPE_PREFIX:
-        prefix_ = tk_prefix(("", period), gfyear, type=PREFIXTYPE_NORMAL)
+        prefix = tk_prefix(("", period), gfyear, type=PREFIXTYPE_NORMAL)
     else:
         raise ValueError("\'%s\' is not a valid type-parameter" % type)
-    return "" + prefix_ + root + postfix_
+    return "" + prefix + root + postfix
 
 
 def parse(alias, gfyear=gfyear):

--- a/tktitler.py
+++ b/tktitler.py
@@ -179,7 +179,7 @@ def parse_prefix(prefix):
     return sum(factors)
 
 
-def parse_postfix(postfix):
+def _parse_postfix(postfix):
     if not isinstance(postfix, str):
         raise TypeError(type(postfix))
     if not postfix:
@@ -224,7 +224,7 @@ def parse_relative(input_alias):
     pre, root, post = mo.group('pre', 'root', 'post')
     assert alias == pre + root + post
     age = parse_prefix(pre)
-    gfyear = parse_postfix(post)
+    gfyear = _parse_postfix(post)
     return age, root, gfyear
 
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -48,7 +48,7 @@ class _Override(object):
         return wrapped
 
 
-def override(gfyear):
+def set_gfyear(gfyear):
     return _Override(gfyear)
 
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -86,7 +86,9 @@ def tk_prefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
         return 'T%sO%s' % (sup_fn(age - 3), root)
 
 
-def tk_kprefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
+def tk_kprefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
+    gfyear = _validate(titletupel, gfyear)
+
     root, period = titletupel
     age = gfyear - period
     if age <= -1:

--- a/tktitler.py
+++ b/tktitler.py
@@ -83,19 +83,16 @@ def tk_prefix(title, gfyear=None, type=PREFIXTYPE_NORMAL):
     elif age + 1 < len(prefix):
         return prefix[age + 1] + root
     else:
-        return 'T%sO%s' % (sup_fn(age - 3), root)
+        return 'T%sO' % sup_fn(age - 3) + root
 
 
 def tk_kprefix(title, gfyear=None, type=PREFIXTYPE_NORMAL):
     gfyear = _validate(title, gfyear)
 
     root, period = title
-    age = gfyear - period
-    if age <= -1:
+    if gfyear < period:
         return tk_prefix((root, period), gfyear, type)
-
-    period -= 1
-    return "K" + tk_prefix((root, period), gfyear, type)
+    return "K" + tk_prefix((root, period - 1), gfyear, type)
 
 
 POSTFIXTYPE_SINGLE = "single"  # FUHØ11

--- a/tktitler.py
+++ b/tktitler.py
@@ -168,7 +168,7 @@ def _normalize(input_alias):
     return re.sub(r'[^0-9A-ZÆØÅ]', lambda mo: tr(mo.group(0)), s)
 
 
-def parse_prefix(prefix):
+def _parse_prefix(prefix):
     pattern = r"^([KGBOT][KGBOT0-9]*)?$"
     if not re.match(pattern, prefix):
         raise ValueError(prefix)
@@ -223,7 +223,7 @@ def parse_relative(input_alias):
     assert mo is not None
     pre, root, post = mo.group('pre', 'root', 'post')
     assert alias == pre + root + post
-    age = parse_prefix(pre)
+    age = _parse_prefix(pre)
     gfyear = _parse_postfix(post)
     return age, root, gfyear
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -6,7 +6,7 @@ import functools
 import unicodedata
 
 
-_gfyear = 2016
+_gfyear = _GFYEAR_UNSET = object()
 
 
 PREFIXTYPE_NORMAL = "normal"
@@ -18,6 +18,9 @@ def get_gfyear(argument_gfyear=None):
         r = _gfyear
     else:
         r = argument_gfyear
+    if r is _GFYEAR_UNSET:
+        raise ValueError("No context gfyear set. Use the gfyear argument " +
+                         "or set_gfyear.")
     if not isinstance(r, int):
         raise TypeError(
             "%s is not a valid type for gfyear." % type(r).__name__)

--- a/tktitler.py
+++ b/tktitler.py
@@ -83,7 +83,7 @@ def tk_prefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
         return 'T%sO%s' % (sup_fn(age - 3), root)
 
 
-def ktk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
+def tk_kprefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
     root, period = titletupel
     age = gfyear - period
     if age <= -1:

--- a/tktitler.py
+++ b/tktitler.py
@@ -42,7 +42,7 @@ def tk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
         return 'T%sO%s' % (sup_fn(age - 3), root)
 
 
-def kprefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
+def ktk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):
     root, period = titletupel
     age = gfyear - period
     if age <= -1:

--- a/tktitler.py
+++ b/tktitler.py
@@ -105,8 +105,8 @@ POSTFIXTYPE_LONGSINGLE = "longsingle"  # FUHØ2011
 POSTFIXTYPE_LONGSLASH = "longslash"  # FUHØ2011/2012
 
 
-def tk_postfix(titletupel, gfyear=None, type=POSTFIXTYPE_SINGLE):
-    gfyear = _validate(titletupel, gfyear)
+def tk_postfix(titletupel, type=POSTFIXTYPE_SINGLE):
+    _validate_title(titletupel)
 
     root, period = titletupel
     root = _funny_substitute(root)

--- a/tktitler.py
+++ b/tktitler.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import re
+import functools
 
 
 gfyear = 2016
@@ -9,6 +10,32 @@ gfyear = 2016
 
 PREFIXTYPE_NORMAL = "normal"
 PREFIXTYPE_UNICODE = "unicode"
+
+
+class _Override(object):
+    def __init__(self, context_gfyear):
+        self.context_gfyear = context_gfyear
+
+    def __enter__(self):
+        global gfyear
+        self.prev_gfyear = gfyear
+        gfyear = self.context_gfyear
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        global gfyear
+        gfyear = self.prev_gfyear
+
+    def __call__(self, fun):
+        @functools.wraps(fun)
+        def wrapped(*args, **kwargs):
+            with self:
+                return fun(*args, **kwargs)
+
+        return wrapped
+
+
+def override(gfyear):
+    return _Override(gfyear)
 
 
 def tk_prefix(titletupel, gfyear=gfyear, type=PREFIXTYPE_NORMAL):

--- a/tktitler.py
+++ b/tktitler.py
@@ -6,7 +6,7 @@ import functools
 import unicodedata
 
 
-gfyear = 2016
+_gfyear = 2016
 
 
 PREFIXTYPE_NORMAL = "normal"
@@ -15,7 +15,7 @@ PREFIXTYPE_UNICODE = "unicode"
 
 def get_gfyear(argument_gfyear=None):
     if argument_gfyear is None:
-        r = gfyear
+        r = _gfyear
     else:
         r = argument_gfyear
     if not isinstance(r, int):
@@ -31,13 +31,13 @@ class _Override(object):
         self.context_gfyear = context_gfyear
 
     def __enter__(self):
-        global gfyear
-        self.prev_gfyear = gfyear
-        gfyear = self.context_gfyear
+        global _gfyear
+        self.prev_gfyear = _gfyear
+        _gfyear = self.context_gfyear
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        global gfyear
-        gfyear = self.prev_gfyear
+        global _gfyear
+        _gfyear = self.prev_gfyear
 
     def __call__(self, fun):
         @functools.wraps(fun)

--- a/tktitler.py
+++ b/tktitler.py
@@ -220,7 +220,7 @@ def parse_relative(input_alias):
              'E?FU(?:%s){2}|' % letter +
              'BEST|FU')
     known_pattern = '^%s(?P<root>%s)%s$' % (prefix, known, postfix)
-    any_pattern = '^%s(?P<root>.*)%s' % (prefix, postfix)
+    any_pattern = '^%s(?P<root>.*?)%s$' % (prefix, postfix)
     mo = re.match(known_pattern, alias) or re.match(any_pattern, alias)
     assert mo is not None
     pre, root, post = mo.group('pre', 'root', 'post')

--- a/tktitler.py
+++ b/tktitler.py
@@ -149,8 +149,9 @@ def email(titletupel, gfyear=None, type=EMAILTYPE_POSTFIX):
     return prefix + root + postfix
 
 
-def parse(alias, gfyear=gfyear):
-    pass  # return (root, period)
+def parse(alias, gfyear=None):
+    gfyear = get_gfyear(gfyear)
+    # return (root, period)
 
 
 def _validate(titletupel, gfyear):
@@ -196,7 +197,7 @@ def _multireplace(string, replacements):
     return regexp.sub(lambda match: replacements[match.group(0)], string)
 
 
-def get_period(prefix, postfix, gfyear):
+def get_period(prefix, postfix, gfyear=None):
     """
     Parse a given prefix and postfix into a period.
     prefix and postfix are possibly empty strings,
@@ -224,6 +225,8 @@ def get_period(prefix, postfix, gfyear):
     >>> get_period("O", "2016", 2030)
     2013
     """
+
+    gfyear = get_gfyear(gfyear)
 
     prefix = prefix.upper()
     if not re.match(r'^([KGBOT][0-9]*)*$', prefix):
@@ -273,7 +276,7 @@ def get_period(prefix, postfix, gfyear):
     return period - grad
 
 
-def parse_bestfu_alias(alias, gfyear):
+def parse_bestfu_alias(alias, gfyear=None):
     """
     Resolve a BEST/FU alias into a (kind, root, period)-tuple
     where kind is 'BEST', 'FU' or 'EFU',
@@ -282,6 +285,8 @@ def parse_bestfu_alias(alias, gfyear):
     >>> parse_bestfu_alias('OFORM', 2016)
     ('BEST', 'FORM', 2013)
     """
+
+    gfyear = get_gfyear(gfyear)
 
     alias = alias.upper()
     prefix_pattern = r"(?P<pre>(?:[KGBOT][KGBOT0-9]*)?)"

--- a/tktitler.py
+++ b/tktitler.py
@@ -292,7 +292,7 @@ def get_period(prefix, postfix, gfyear=None):
     If only a prefix is given, it is subtracted from the gfyear:
     >>> get_period("B", "", 2016)
     2014
-    >>> get_period("T30", "", 2016)
+    >>> get_period("T3O", "", 2016)
     2010
     >>> get_period("G2B2", "", 2016)
     2010

--- a/tktitler.py
+++ b/tktitler.py
@@ -55,10 +55,10 @@ def set_gfyear(gfyear):
     return _Override(gfyear)
 
 
-def tk_prefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
-    gfyear = _validate(titletupel, gfyear)
+def tk_prefix(title, gfyear=None, type=PREFIXTYPE_NORMAL):
+    gfyear = _validate(title, gfyear)
 
-    root, period = titletupel
+    root, period = title
     root = _funny_substitute(root)
     age = gfyear - period
 
@@ -86,10 +86,10 @@ def tk_prefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
         return 'T%sO%s' % (sup_fn(age - 3), root)
 
 
-def tk_kprefix(titletupel, gfyear=None, type=PREFIXTYPE_NORMAL):
-    gfyear = _validate(titletupel, gfyear)
+def tk_kprefix(title, gfyear=None, type=PREFIXTYPE_NORMAL):
+    gfyear = _validate(title, gfyear)
 
-    root, period = titletupel
+    root, period = title
     age = gfyear - period
     if age <= -1:
         return tk_prefix((root, period), gfyear, type)
@@ -105,10 +105,10 @@ POSTFIXTYPE_LONGSINGLE = "longsingle"  # FUHØ2011
 POSTFIXTYPE_LONGSLASH = "longslash"  # FUHØ2011/2012
 
 
-def tk_postfix(titletupel, type=POSTFIXTYPE_SINGLE):
-    _validate_title(titletupel)
+def tk_postfix(title, type=POSTFIXTYPE_SINGLE):
+    _validate_title(title)
 
-    root, period = titletupel
+    root, period = title
     root = _funny_substitute(root)
 
     postfix = ""
@@ -134,10 +134,10 @@ EMAILTYPE_POSTFIX = "postfix"  # FUHOE11
 EMAILTYPE_PREFIX = "prefix"  # T2OFUHOE
 
 
-def email(titletupel, gfyear=None, type=EMAILTYPE_POSTFIX):
-    gfyear = _validate(titletupel, gfyear)
+def email(title, gfyear=None, type=EMAILTYPE_POSTFIX):
+    gfyear = _validate(title, gfyear)
 
-    root, period = titletupel
+    root, period = title
 
     replace_dict = {'æ': 'ae', 'ø': 'oe', 'å': 'aa',
                     'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA'}
@@ -239,8 +239,8 @@ def parse(alias, gfyear=None):
     return root, gfyear - age
 
 
-def _validate_title(titletupel):
-    root, period = titletupel
+def _validate_title(title):
+    root, period = title
     if not isinstance(root, str):
         raise TypeError(
             "%s is not a valid type for root." % type(root).__name__)
@@ -251,8 +251,8 @@ def _validate_title(titletupel):
         raise ValueError("\'%s\' is not a valid period" % period)
 
 
-def _validate(titletupel, gfyear):
-    _validate_title(titletupel)
+def _validate(title, gfyear):
+    _validate_title(title)
     return get_gfyear(gfyear)
 
 


### PR DESCRIPTION
* Omdøb `prefix`, `postfix`, `kprefix` funktioner
* Erstat `"" + ...` med `assert isinstance(..., str)`
* Tilføj `get_gfyear` funktion til at oversætte `gfyear=None` til nuværende context gfyear
* Tilføj `override` context manager + decorator til at ændre context gfyear
* Implementér `parse`