### PR TITLE
Normalize escaped FU-titles

### DIFF
--- a/test.py
+++ b/test.py
@@ -274,10 +274,10 @@ class TestParseRelative(unittest.TestCase):
         self.assertEqual(parse_relative('GFU14'), (1, 'FU', 2014))
 
     def test_fu_int(self):
-        self.assertEqual(parse_relative('GFUOEAE14'), (1, 'FUOEAE', 2014))
+        self.assertEqual(parse_relative('GFUOEAE14'), (1, 'FUØÆ', 2014))
 
     def test_lower(self):
-        self.assertEqual(parse_relative('gfuoeae14'), (1, 'FUOEAE', 2014))
+        self.assertEqual(parse_relative('gfuoeae14'), (1, 'FUØÆ', 2014))
 
     def test_unicode_superscript(self):
         self.assertEqual(parse_relative('T²OFORM'), (5, 'FORM', None))
@@ -461,6 +461,50 @@ class TestParse(unittest.TestCase):
     def test_prefix_bestfuslash(self):
         with set_gfyear(2013):
             self.assertEqual(parse('BBEST/FU'), ('BESTFU', 2011))
+
+    def test_AE_1(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUAE11'), ('FUAE', 2011))
+
+    def test_AE_2(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUHAE11'), ('FUHÆ', 2011))
+
+    def test_AE_3(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUAEH11'), ('FUÆH', 2011))
+
+    def test_OE_1(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUOE11'), ('FUOE', 2011))
+
+    def test_OE_2(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUHOE11'), ('FUHØ', 2011))
+
+    def test_OE_3(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUOEH11'), ('FUØH', 2011))
+
+    def test_AA_1(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUAA11'), ('FUAA', 2011))
+
+    def test_AA_2(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUHAA11'), ('FUHÅ', 2011))
+
+    def test_AA_3(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUAAH11'), ('FUÅH', 2011))
+
+    def test_OEAA(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUOEAA11'), ('FUØÅ', 2011))
+
+    def test_AAAA(self):
+        with set_gfyear(2013):
+            self.assertEqual(parse('FUAAAA11'), ('FUÅÅ', 2011))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -506,6 +506,20 @@ class TestParse(unittest.TestCase):
         with set_gfyear(2013):
             self.assertEqual(parse('FUAAAA11'), ('FUÅÅ', 2011))
 
+    def test_AAA(self):
+        with set_gfyear(2013):
+            with self.assertRaisesRegex(ValueError,
+                                        "FUAAA is an ambiguous alias. Cannot "
+                                        "normalize."):
+                parse('FUAAA11')
+
+    def test_AAE(self):
+        with set_gfyear(2013):
+            with self.assertRaisesRegex(ValueError,
+                                        "FUAAE is an ambiguous alias. Cannot "
+                                        "normalize."):
+                parse('FUAAE11')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tktitler.py
+++ b/tktitler.py
@@ -249,7 +249,8 @@ def parse_relative(input_alias):
     known = ('CERM|FORM|INKA|KASS|NF|PR|SEKR|VC|' +
              'E?FU(?:%s){2}|' % letter +
              'BEST|FU|BESTFU')
-    known_escaped_pattern = '^%s(?P<root>%s)%s$' % (prefix, known_escaped, postfix)
+    known_escaped_pattern = '^%s(?P<root>%s)%s$' % (prefix, known_escaped,
+                                                    postfix)
     known_pattern = '^%s(?P<root>%s)%s$' % (prefix, known, postfix)
     any_pattern = '^%s(?P<root>.*?)%s$' % (prefix, postfix)
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -176,6 +176,8 @@ def _normalize(input_alias):
 
 
 def _normalize_escaped(alias):
+    if ("AAA" in alias and "AAAA" not in alias) or "AAE" in alias:
+        raise ValueError("%s is an ambiguous alias. Cannot normalize." % alias)
     replace_dict = {'OE': 'Ø',
                     'AE': 'Æ',
                     'AA': 'Å'}


### PR DESCRIPTION
@Mortal vil vi normalisere escapede FU titler i `parse()`?

`parse("FUHOE16") -> ("FUHØ", 2016)`

Hvis ja, vil du så kigge på `known_escaped` regexp'et?