### PR TITLE
Parsing 'TVC'

### DIFF
--- a/test.py
+++ b/test.py
@@ -391,13 +391,25 @@ class TestParseRelative(unittest.TestCase):
         self.assertEqual(tk._parse_relative('GFORM'), (1, 'FORM', None))
 
     def test_multi_prefix(self):
-        self.assertEqual(tk._parse_relative('BTKFORM'), (2, 'FORM', None))
+        self.assertEqual(tk._parse_relative('BTOKFORM'), (5, 'FORM', None))
 
     def test_bent(self):
         self.assertEqual(tk._parse_relative('TVC02'), (0, 'TVC', 2002))
 
     def test_temp_title(self):
         self.assertEqual(tk._parse_relative('BTFORM'), (2, 'TFORM', None))
+
+    def test_t_before_k(self):
+        self.assertEqual(tk._parse_relative('TKFORM'), (0, 'TKFORM', None))
+
+    def test_t_before_g(self):
+        self.assertEqual(tk._parse_relative('TGFORM'), (0, 'TGFORM', None))
+
+    def test_t_before_b(self):
+        self.assertEqual(tk._parse_relative('TBFORM'), (0, 'TBFORM', None))
+
+    def test_t3_before_b(self):
+        self.assertEqual(tk._parse_relative('T3BFORM'), (0, 'T3BFORM', None))
 
     def test_exponent(self):
         self.assertEqual(tk._parse_relative('OT2OFORM'), (8, 'FORM', None))

--- a/test.py
+++ b/test.py
@@ -393,6 +393,12 @@ class TestParseRelative(unittest.TestCase):
     def test_multi_prefix(self):
         self.assertEqual(tk._parse_relative('BTKFORM'), (2, 'FORM', None))
 
+    def test_bent(self):
+        self.assertEqual(tk._parse_relative('TVC02'), (0, 'TVC', 2002))
+
+    def test_temp_title(self):
+        self.assertEqual(tk._parse_relative('BTFORM'), (2, 'TFORM', None))
+
     def test_exponent(self):
         self.assertEqual(tk._parse_relative('OT2OFORM'), (8, 'FORM', None))
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -428,7 +428,7 @@ def _normalize_escaped(alias):
 
 
 def _parse_prefix(prefix):
-    pattern = r"^([KGBOT][KGBOT0-9]*)?$"
+    pattern = r"^(([KGBO]|T[0-9T]*O)[0-9]*)*$"
     if not re.match(pattern, prefix):
         raise ValueError(prefix)
     prefix_value = dict(K=-1, G=1, B=2, O=3, T=1)
@@ -489,7 +489,7 @@ def _parse_postfix(postfix):
 
 def _parse_relative(input_alias):
     alias = _normalize(input_alias)
-    prefix = r"(?P<pre>(?:[KGBOT][KGBOT0-9]*[KGBO0-9]|[KGBO])?)"
+    prefix = r"(?P<pre>((([KGBO]|T[0-9T]*O)[0-9]*)*))"
     postfix = r"(?P<post>([0-9/])*)"
     letter = '[A-Z]|Æ|Ø|Å'
     known_escaped = 'E?FU((AE|OE|AA){2}|(AE|OE|AA)[A-Z]|[A-Z](AE|OE|AA))'

--- a/tktitler.py
+++ b/tktitler.py
@@ -489,7 +489,7 @@ def _parse_postfix(postfix):
 
 def _parse_relative(input_alias):
     alias = _normalize(input_alias)
-    prefix = r"(?P<pre>(?:[KGBOT][KGBOT0-9]*)?)"
+    prefix = r"(?P<pre>(?:[KGBOT][KGBOT0-9]*[KGBO0-9]|[KGBO])?)"
     postfix = r"(?P<post>([0-9/])*)"
     letter = '[A-Z]|Æ|Ø|Å'
     known_escaped = 'E?FU((AE|OE|AA){2}|(AE|OE|AA)[A-Z]|[A-Z](AE|OE|AA))'


### PR DESCRIPTION
Lige nu bliver 'TVC' parset som 'VC' med alder 1. 'TVC' blev dog brugt som titel i 2002/03 da man havde behov for en suppleant, så 'TVC' bør parses som en egentlig titel.

Skal vi sige at et præfiks ikke må slutte på T? Så tillader vi også andre 'T'+BEST-titler hvis behovet skulle opstå i fremtiden.

Det vil betyde at mailsystemet (når det kommer til at bruge tktitler) ikke vil videresende f.eks. mails sendt til BTVC@TAAGEKAMMERET.dk til OVC, men i stedet give en parserfejl da TVC ikke findes i BBEST. Heldigvis er der ikke nogen der har sendt til `T(CERM|FORM|KASS|INKA|NF|PR|SEKR|VC)` ifølge den log jeg har over mails sendt de sidste to år. (De eneste søgeresultater drejede sig om Katinka og Platform).