### PR TITLE
Passing callable to set_gfyear

### DIFF
--- a/test.py
+++ b/test.py
@@ -742,5 +742,47 @@ class TestTex(unittest.TestCase):
             r'OKA\$\$')
 
 
+class TestCallable(unittest.TestCase):
+
+    def test_lambda(self):
+        with tk.set_gfyear(lambda: 2013):
+            self.assertEqual(tk.get_gfyear(), 2013)
+
+    def test_called_once(self):
+        calls = 0
+
+        def get_value():
+            nonlocal calls
+            calls += 1
+            return 2013
+
+        o = tk.set_gfyear(get_value)
+        self.assertEqual(calls, 0)
+        with o:
+            self.assertEqual(calls, 1)
+            self.assertEqual(tk.get_gfyear(), 2013)
+            self.assertEqual(calls, 1)
+            self.assertEqual(tk.get_gfyear(), 2013)
+            self.assertEqual(calls, 1)
+
+    def test_called_every_time(self):
+        calls = 0
+
+        def get_value():
+            nonlocal calls
+            calls += 1
+            return 2013
+
+        @tk.set_gfyear(get_value)
+        def f():
+            pass
+
+        self.assertEqual(calls, 0)
+        f()
+        self.assertEqual(calls, 1)
+        f()
+        self.assertEqual(calls, 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tktitler.py
+++ b/tktitler.py
@@ -58,12 +58,18 @@ def get_gfyear(gfyear=None):
 
 class _Override(object):
     def __init__(self, context_gfyear):
-        self.context_gfyear = context_gfyear
+        if callable(context_gfyear):
+            self.context_gfyear_callable = context_gfyear
+        else:
+            self.context_gfyear = context_gfyear
 
     def __enter__(self):
         global _gfyear
         self.prev_gfyear = _gfyear
-        _gfyear = self.context_gfyear
+        try:
+            _gfyear = self.context_gfyear
+        except AttributeError:
+            _gfyear = self.context_gfyear_callable()
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         global _gfyear

--- a/tktitler.py
+++ b/tktitler.py
@@ -117,6 +117,16 @@ def set_gfyear(gfyear):
     >>> y = 2015
     >>> foo()
     'OFORM'
+
+    Hvis man bruger constance, kan man eksempelvis hente året fra databasen:
+
+    >>> from constance import config  # doctest: +SKIP
+    >>> @tk.set_gfyear(lambda: config.GFYEAR)
+    ... def get_title_list(titles):
+    ...     result = []
+    ...     for x in titles:
+    ...         result.append(tk.prefix(x))
+    ...     return ', '.join(result)
     '''
     return _Override(gfyear)
 

--- a/tktitler.py
+++ b/tktitler.py
@@ -103,6 +103,20 @@ def set_gfyear(gfyear):
     ...     return tk.prepostfix(title)
     >>> get_j60_name(('FORM', 2013))
     'OFORM 2013/14'
+
+    Man kan give en lambda som argument for at beregne året på ny hver gang
+    funktionen bliver kaldt. Den givne lambda bliver kaldt én gang i starten
+    af funktionen. For eksempel:
+
+    >>> y = 2013
+    >>> @tk.set_gfyear(lambda: y)
+    ... def foo():
+    ...     return tk.prefix(('FORM', 2012))
+    >>> foo()
+    'GFORM'
+    >>> y = 2015
+    >>> foo()
+    'OFORM'
     '''
     return _Override(gfyear)
 


### PR DESCRIPTION
Hvis man vil bruge `tk.set_gfyear` som decorator, er det ikke så nyttigt hvis året skal kendes når funktionen defineres. Det er mere nyttigt hvis gfåret først bliver beregnet når funktionen kaldes. Hvis man kan give f.eks. `lambda: config.GFYEAR` til `set_gfyear`-decoratoren på et Django-view, så vil gfåret blive hentet på ny fra `config` hver gang viewet kører -- og det er smart.