### PR TITLE
Add UE digraph for Ü

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@
 .. currentmodule:: tktitler
 
 
+1.0.x (2017-xx-xx)
+------------------
+
+- Tilføj 'UE' som forlængelse af 'Ü'
+
+
 1.0.0b1 (2016-01-24)
 ------------------
 

--- a/test.py
+++ b/test.py
@@ -291,6 +291,12 @@ class TestEmail(unittest.TestCase):
     def test_KASS(self):
         self.assertEqual(tk.email(("KA$$", 2011), 2016), "KASS11")
 
+    def test_ue_upper(self):
+        self.assertEqual(tk.email(("FUOÜ", 2017), 2017), "FUOUE17")
+
+    def test_ue_lower(self):
+        self.assertEqual(tk.email(("fuoü", 2017), 2017), "FUOUE17")
+
     def test_postfix(self):
         self.assertEqual(
             tk.email(("FUHØ", 2011), 2016, type='postfix'),
@@ -428,6 +434,9 @@ class TestParseRelative(unittest.TestCase):
 
     def test_fu_int(self):
         self.assertEqual(tk._parse_relative('GFUOEAE14'), (1, 'FUØÆ', 2014))
+
+    def test_fu_int_2(self):
+        self.assertEqual(tk._parse_relative('FUOUE'), (0, 'FUOÜ', None))
 
     def test_lower(self):
         self.assertEqual(tk._parse_relative('gfuoeae14'), (1, 'FUØÆ', 2014))

--- a/tktitler.py
+++ b/tktitler.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 _gfyear = _GFYEAR_UNSET = object()
 
 DIGRAPHS = {'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA', 'Ü': 'UE'}
+'Dictionary der mapper hvert stort dansk bogstav til en ASCII-forlængelse.'
 
 
 class _TitleABC(metaclass=abc.ABCMeta):

--- a/tktitler.py
+++ b/tktitler.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 _gfyear = _GFYEAR_UNSET = object()
 
-DIGRAPHS = {'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA'}
+DIGRAPHS = {'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA', 'Ü': 'UE'}
 
 
 def digraphs_lower():

--- a/tktitler.py
+++ b/tktitler.py
@@ -17,10 +17,6 @@ _gfyear = _GFYEAR_UNSET = object()
 DIGRAPHS = {'Æ': 'AE', 'Ø': 'OE', 'Å': 'AA', 'Ü': 'UE'}
 
 
-def digraphs_lower():
-    return {ch.lower(): di.lower() for ch, di in DIGRAPHS.items()}
-
-
 class _TitleABC(metaclass=abc.ABCMeta):
     pass
 
@@ -439,7 +435,8 @@ def email(title, gfyear=None, *, type=_EMAILTYPE_POSTFIX):
 
     root = _normalize(root)
     root = _multireplace(root, DIGRAPHS)
-    root = _multireplace(root, digraphs_lower())
+    digraphs_lower = {ch.lower(): di.lower() for ch, di in DIGRAPHS.items()}
+    root = _multireplace(root, digraphs_lower)
 
     if root == 'EFUIT' and type == _EMAILTYPE_POSTFIX:
         logger.warning('Returning an EFUIT email with postfix. The postfix '

--- a/tktitler.py
+++ b/tktitler.py
@@ -488,6 +488,21 @@ def _normalize(input_alias):
 
 
 def _normalize_escaped(alias):
+    # The grammar
+    #     S -> "FU" letter letter
+    #     letter -> ascii | extended
+    #     ascii -> "A" | ... | "Z"
+    #     extended -> "AA" | "AE"
+    # is ambiguous, since "FUAAA" and "FUAAE" have two derivations each:
+    #     "FUAAA" == "FU" + "AA" + "A" == "FU" + "A" + "AA"
+    #     "FUAAE" == "FU" + "AA" + "E" == "FU" + "A" + "AE"
+    # The problem arises whenever 'extended' has two productions where the
+    # first letter in one production is the last letter in another, i.e.
+    #     extended -> c1 c2
+    #     extended -> c2 c3
+    #     ascii -> c1 | c2 | c3
+    # since in that case "FU" c1 c2 c3 is ambiguous: "FU" (c1 c2) c3 or
+    # "FU" c1 (c2 c3).
     if ("AAA" in alias and "AAAA" not in alias) or "AAE" in alias:
         raise ValueError("%s is an ambiguous alias. Cannot normalize." % alias)
     replace_dict = {


### PR DESCRIPTION
Vi har fået en FUOÜ. Det kræver at tktitler understøtter Ü <-> UE. Jeg har refactoret håndteringen af digraphs (AE, OE, AA, UE) og tilføjet den nye digraph.